### PR TITLE
Replace custom AJAX handlers with REST API request

### DIFF
--- a/assets/js/wca2-ajax.js
+++ b/assets/js/wca2-ajax.js
@@ -27,15 +27,15 @@
 				return;
 			}
 
-			$.post(
-				wca2.ajaxUrl,
+			$.get(
+				'/wp-json/posts/',
 				{
-					'action' : 'wca2-search',
-					's' : value
+					'search' : value,
+					'per_page' : '5'
 				},
 				function ( response ) {
 					WCA2AJAX.removeSuggestedResults();
-					WCA2AJAX.addSuggestedResults( response.data.results );
+					WCA2AJAX.addSuggestedResults( response );
 				}
 			);
 		},

--- a/wca2-search-suggestions.php
+++ b/wca2-search-suggestions.php
@@ -18,46 +18,5 @@
 function wca2_ajax_enqueue() {
 	wp_enqueue_script( 'wca2-ajax', plugin_dir_url( __FILE__ ) . 'assets/js/wca2-ajax.js', 'jquery', '1.0.0', true );
 	wp_enqueue_style( 'wca2-ajax', plugin_dir_url(__FILE__ ) . 'assets/css/wca2-frontend.css', null, '1.0.0' );
-	wp_localize_script( 'wca2-ajax', 'wca2', array( 'ajaxUrl' => admin_url( 'admin-ajax.php' ) ) );
 }
 add_action( 'wp_enqueue_scripts', 'wca2_ajax_enqueue' );
-
-/**
- * AJAX Handler for realtime search suggestions.
- *
- * @since 0.1.0
- */
-function wca2_ajax_search_response() {
-
-	$search = isset( $_REQUEST['s'] ) ? sanitize_text_field( $_REQUEST['s'] ) : '';
-	$results = wca2_get_suggested_results( $search );
-
-	wp_send_json_success( array(
-		'searchString' => $search,
-		'results'      => $results,
-	) );
-}
-add_action( 'wp_ajax_wca2-search', 'wca2_ajax_search_response' );
-add_action( 'wp_ajax_nopriv_wca2-search', 'wca2_ajax_search_response' );
-
-/**
- * Get the suggested search results.
- *
- * @since  0.1.0
- *
- * @param  string $search Search string.
- * @return array          WP Posts.
- */
-function wca2_get_suggested_results( $search = '' ) {
-	$results = get_posts( array(
-		's' => $search,
-		'posts_per_page' => 5,
-	) );
-
-	foreach ( $results as $result ) {
-		$result->title = $result->post_title;
-		$result->link = get_permalink( $result->ID );
-	}
-
-	return $results;
-}


### PR DESCRIPTION
Instead of registering a custom AJAX action and running a custom WP_Query let's leverage the WP REST API.

This strips a ton of code from our plugin and gives us some hidden performance improvements. However, it does make us dependent on the WP REST API plugin _(for now!)_.
